### PR TITLE
Feature/upload symbols to tpa action

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To ge
 fastlane add_plugin tpa
 ```
 
+## Actions
+
+This plugin provides two actions for interacting with TPA:
+
+- `tpa`: Uploads a given iOS or Android build to TPA
+- `upload_symbols_to_tpa_action`: Uploads the given dSYM files to TPA
+
 ## About tpa
 
 TPA gives you advanced user behaviour analytics, app distribution, crash analytics and more

--- a/fastlane-plugin-tpa.gemspec
+++ b/fastlane-plugin-tpa.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'rest-client', '~> 2.0.2'
+
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -1,0 +1,47 @@
+require 'fastlane/action'
+require_relative '../helper/upload_symbols_to_tpa_helper'
+
+module Fastlane
+  module Actions
+    class UploadSymbolsToTpaAction < Action
+      def self.run(params)
+        UI.message("The upload_symbols_to_tpa plugin is working!")
+      end
+
+      def self.description
+        "Upload dsym files downloaded from iTunesConnect directly to TPA"
+      end
+
+      def self.authors
+        ["Stefan Veis Pennerup"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "If your app uses Bitcode, then the final dsym files are not generated upon compile time. Instead you have to go to iTunesConnect and downloade the dsym files after Apple has processed your app. Afterwards you need to upload these files to TPA in order to allow for symbolication of the crash reports. You can use this plugin to streamline and automate this whole process."
+      end
+
+      def self.available_options
+        [
+          # FastlaneCore::ConfigItem.new(key: :your_option,
+          #                         env_name: "UPLOAD_SYMBOLS_TO_TPA_YOUR_OPTION",
+          #                      description: "A description of your option",
+          #                         optional: false,
+          #                             type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
+        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
+        #
+        # [:ios, :mac, :android].include?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -37,30 +37,12 @@ module Fastlane
         UI.success("Successfully uploaded dSYM files to TPA 🎉")
       end
 
-      # Extracts the TPA host name from the upload_url using a regular expression
-      def self.tpa_host(params)
-        match_groups = params[:upload_url].match("^(?<tpa_host>https:\/\/.*)\/.+\/upload$")
-        if match_groups.nil?
-          raise "Failed to extract TPA host from the provided upload url. Please double check that the given upload url is correct."
-        end
-        return match_groups[:tpa_host]
-      end
-
-      # Extracts the API UUID from the upload_url using a regular expression
-      def self.api_uuid(params)
-        match_groups = params[:upload_url].match("^https:\/\/.*\/(?<api_uuid>.+)\/upload$")
-        if match_groups.nil?
-          raise "Failed to extract API UUID from the provided upload url. Please double check that the given upload url is correct."
-        end
-        return match_groups[:api_uuid]
-      end
-
       def self.download_known_dsyms(params)
         UI.message("Downloading list of dSYMs already uploaded to TPA...")
 
-        tpa_host = tpa_host(params)
-        api_uuid = api_uuid(params)
-        app_identifier = params[:app_identifier]
+        tpa_host = Helper::UploadSymbolsToTpaHelper.tpa_host(params)
+        api_uuid = Helper::UploadSymbolsToTpaHelper.api_uuid(params)
+        app_identifier = Helper::UploadSymbolsToTpaHelper.app_identifier(params)
         url = "#{tpa_host}/rest/api/v2/projects/#{api_uuid}/apps/#{app_identifier}/symbols/"
 
         begin
@@ -106,13 +88,13 @@ module Fastlane
           meta_data = parse_meta_data(path)
 
           # Double checks that the app_identifier is as intended
-          unless meta_data[:app_identifier] == params[:app_identifier]
+          unless meta_data[:app_identifier] == Helper::UploadSymbolsToTpaHelper.app_identifier(params)
             raise "App identifier of dSYM path does not match app identifier specified in Fastfile"
           end
 
           # Constructs the url
-          tpa_host = tpa_host(params)
-          api_uuid = api_uuid(params)
+          tpa_host = Helper::UploadSymbolsToTpaHelper.tpa_host(params)
+          api_uuid = Helper::UploadSymbolsToTpaHelper.api_uuid(params)
           url = "#{tpa_host}/rest/api/v2/projects/#{api_uuid}/apps/#{meta_data[:app_identifier]}/versions/#{meta_data[:build]}/symbols/"
 
           # Uploads the dSYM to TPA

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -26,7 +26,7 @@ module Fastlane
 
         UI.success("Successfully uploaded dSYM files to TPA 🎉")
       end
-      
+
       def self.upload_dsym(params, path)
         UI.message("Uploading '#{path}'...")
         identifier, version, build = File.basename(path, ".dSYM.zip").split('-')
@@ -36,7 +36,7 @@ module Fastlane
         command << "-F mapping=#{path}"
         command << "-F identifier=#{identifier}"
         command << "-F version=#{version}"
-        command << "#{params[:upload_url]}" 
+        command << (params[:upload_url]).to_s
         begin
           command_to_execute = command.join(" ")
           UI.verbose("upload_dsym using command: #{command_to_execute}")

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -5,42 +5,110 @@ module Fastlane
   module Actions
     class UploadSymbolsToTpaAction < Action
       def self.run(params)
-        UI.message("The upload_symbols_to_tpa plugin is working!")
+        # Params - dSYM
+        dsym_paths = []
+        dsym_paths << params[:dsym_path] if params[:dsym_path]
+        dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
+
+        if dsym_paths.count == 0
+          UI.error("Couldn't find any dSYMs, please pass them using the dsym_path option")
+          return nil
+        end
+
+        # Get rid of duplicate dSYMs (which might occur when both passed and detected)
+        dsym_paths = dsym_paths.collect { |a| File.expand_path(a) }
+        dsym_paths.uniq!
+
+        # Handles each dSYM file
+        dsym_paths.each do |current_path|
+          upload_dsym(params, current_path)
+        end
+
+        UI.success("Successfully uploaded dSYM files to TPA 🎉")
       end
+      
+      def self.upload_dsym(params, path)
+        UI.message("Uploading '#{path}'...")
+        identifier, version, build = File.basename(path, ".dSYM.zip").split('-')
+        command = []
+        command << "curl"
+        command << "--fail"
+        command << "-F mapping=#{path}"
+        command << "-F identifier=#{identifier}"
+        command << "-F version=#{version}"
+        command << "#{params[:upload_url]}" 
+        begin
+          command_to_execute = command.join(" ")
+          UI.verbose("upload_dsym using command: #{command_to_execute}")
+          Actions.sh(command_to_execute, log: false)
+        rescue => ex
+          UI.error(ex.to_s) # it fails, however we don't want to fail everything just for this
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
 
       def self.description
         "Upload dsym files downloaded from iTunesConnect directly to TPA"
+      end
+
+      def self.details
+        [
+          "If your app uses Bitcode, then the final dsym files are not generated upon compile time.",
+          "Instead you have to go to iTunesConnect and downloade the dsym files after Apple has",
+          "processed your app. Afterwards you need to upload these files to TPA in order to allow",
+          "Thefor symbolication of the crash reports. You can use this plugin to streamline and",
+          "automate this whole process."
+        ].join(" ")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :dsym_path,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_TPA_DSYM_PATH",
+                                       description: "Path to the DSYM zip file to upload",
+                                       default_value: ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] || (Dir["./**/*.dSYM.zip"]).sort_by { |f| File.mtime(f) }.last,
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                         UI.user_error!("Symbolication file needs to be zip") unless value.end_with?(".zip")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :upload_url,
+                                       env_name: "FL_TPA_UPLOAD_URL",
+                                       description: "The TPA upload url",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass your TPA Upload URL using `ENV['FL_TPA_UPLOAD_URL'] = 'value'`") unless value
+                                       end)
+        ]
+      end
+
+      def self.output
+        nil
+      end
+
+      def self.return_value
+        nil
       end
 
       def self.authors
         ["Stefan Veis Pennerup"]
       end
 
-      def self.return_value
-        # If your method provides a return value, you can describe here what it does
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
       end
 
-      def self.details
-        # Optional:
-        "If your app uses Bitcode, then the final dsym files are not generated upon compile time. Instead you have to go to iTunesConnect and downloade the dsym files after Apple has processed your app. Afterwards you need to upload these files to TPA in order to allow for symbolication of the crash reports. You can use this plugin to streamline and automate this whole process."
-      end
-
-      def self.available_options
+      def self.example_code
         [
-          # FastlaneCore::ConfigItem.new(key: :your_option,
-          #                         env_name: "UPLOAD_SYMBOLS_TO_TPA_YOUR_OPTION",
-          #                      description: "A description of your option",
-          #                         optional: false,
-          #                             type: String)
+          'upload_symbols_to_tpa(dsym_path: "./App.dSYM.zip")'
         ]
       end
 
-      def self.is_supported?(platform)
-        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
-        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
-        #
-        # [:ios, :mac, :android].include?(platform)
-        true
+      def self.category
+        :misc
       end
     end
   end

--- a/lib/fastlane/plugin/tpa/helper/upload_symbols_to_tpa_helper.rb
+++ b/lib/fastlane/plugin/tpa/helper/upload_symbols_to_tpa_helper.rb
@@ -5,11 +5,29 @@ module Fastlane
 
   module Helper
     class UploadSymbolsToTpaHelper
-      # class methods that you define here become available in your action
-      # as `Helper::UploadSymbolsToTpaHelper.your_method`
-      #
-      def self.show_message
-        UI.message("Hello from the upload_symbols_to_tpa plugin helper!")
+      # Extracts the TPA host name from the parameters
+      def self.tpa_host(params)
+        # Extracts the TPA host name from the upload_url using a regular expression
+        match_groups = params[:upload_url].match("^(?<tpa_host>https:\/\/.*)\/.+\/upload$")
+        if match_groups.nil?
+          raise "Failed to extract TPA host from the provided upload url. Please double check that the given upload url is correct."
+        end
+        return match_groups[:tpa_host]
+      end
+
+      # Extracts the API UUID from the parameters
+      def self.api_uuid(params)
+        # Extracts the API UUID from the upload_url using a regular expression
+        match_groups = params[:upload_url].match("^https:\/\/.*\/(?<api_uuid>.+)\/upload$")
+        if match_groups.nil?
+          raise "Failed to extract API UUID from the provided upload url. Please double check that the given upload url is correct."
+        end
+        return match_groups[:api_uuid]
+      end
+
+      # Extracts the app_identifier from the parameters
+      def self.app_identifier(params)
+        return params[:app_identifier]
       end
     end
   end

--- a/lib/fastlane/plugin/tpa/helper/upload_symbols_to_tpa_helper.rb
+++ b/lib/fastlane/plugin/tpa/helper/upload_symbols_to_tpa_helper.rb
@@ -1,0 +1,16 @@
+require 'fastlane_core/ui/ui'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
+
+  module Helper
+    class UploadSymbolsToTpaHelper
+      # class methods that you define here become available in your action
+      # as `Helper::UploadSymbolsToTpaHelper.your_method`
+      #
+      def self.show_message
+        UI.message("Hello from the upload_symbols_to_tpa plugin helper!")
+      end
+    end
+  end
+end

--- a/spec/upload_symbols_to_tpa_action_spec.rb
+++ b/spec/upload_symbols_to_tpa_action_spec.rb
@@ -1,0 +1,9 @@
+describe Fastlane::Actions::UploadSymbolsToTpaAction do
+  describe '#run' do
+    it 'prints a message' do
+      expect(Fastlane::UI).to receive(:message).with("The upload_symbols_to_tpa plugin is working!")
+
+      Fastlane::Actions::UploadSymbolsToTpaAction.run(nil)
+    end
+  end
+end


### PR DESCRIPTION
Created a new action called `upload_symbols_to_tpa_action` which allows for only uploading dSYM files directly to TPA.

This is useful for apps which have bitcode enabled where dSYM files needs to be downloaded from App Store Connect.