### PR TITLE
Updated tpa_action to use TPA REST API v2

### DIFF
--- a/lib/fastlane/plugin/tpa/actions/tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/tpa_action.rb
@@ -63,7 +63,7 @@ module Fastlane
       end
 
       def self.upload_url(params)
-        "#{params[:tpa_host]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/versions/app/"
+        "#{params[:base_url]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/versions/app/"
       end
 
       def self.verbose(params)

--- a/lib/fastlane/plugin/tpa/actions/tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/tpa_action.rb
@@ -88,7 +88,7 @@ module Fastlane
 
       # rubocop:disable Metrics/MethodLength
       def self.available_options
-        [
+        Fastlane::Helper::TpaHelper.shared_available_options + [
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "FL_TPA_IPA",
                                        description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
@@ -146,31 +146,7 @@ module Fastlane
                                        description: "Show progress bar of upload",
                                        is_string: false,
                                        default_value: true,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :tpa_host,
-                                       env_name: "FL_TPA_HOST_URL",
-                                       description: "The TPA host url",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA host cannot be empty") if value.to_s.length.zero?
-                                         UI.user_error!("Please specify a host name beginning with https://") unless value.start_with?("https://")
-                                         UI.user_error!("Please specify a host name which ends with .tpa.io") unless value.end_with?(".tpa.io", ".tpa.io/")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :api_uuid,
-                                       env_name: "FL_TPA_API_UUID",
-                                       description: "The API UUID of the project",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA API UUID cannot be empty") if value.to_s.length.zero?
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "FL_TPA_API_KEY",
-                                       description: "An API key to TPA",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA API key cannot be empty") if value.to_s.length.zero?
-                                       end)
-
+                                       optional: true)
         ]
       end
       # rubocop:enable Metrics/MethodLength

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -108,7 +108,7 @@ module Fastlane
       end
 
       def self.available_options
-        [
+        Fastlane::Helper::TpaHelper.shared_available_options + [
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_TPA_DSYM_PATH",
                                        description: "Path to the dSYM zip file to upload",
@@ -118,29 +118,6 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                          UI.user_error!("Symbolication file needs to be zip") unless value.end_with?(".zip")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :tpa_host,
-                                       env_name: "FL_TPA_HOST_URL",
-                                       description: "The TPA host url",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA host cannot be empty") if value.to_s.length.zero?
-                                         UI.user_error!("Please specify a host name beginning with https://") unless value.start_with?("https://")
-                                         UI.user_error!("Please specify a host name which ends with .tpa.io") unless value.end_with?(".tpa.io", ".tpa.io/")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :api_uuid,
-                                       env_name: "FL_TPA_API_UUID",
-                                       description: "The API UUID of the project",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA API UUID cannot be empty") if value.to_s.length.zero?
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "FL_TPA_API_KEY",
-                                       description: "An API key to TPA",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The TPA API key cannot be empty") if value.to_s.length.zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",

--- a/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/upload_symbols_to_tpa_action.rb
@@ -40,7 +40,7 @@ module Fastlane
       def self.download_known_dsyms(params)
         UI.message("Downloading list of dSYMs already uploaded to TPA...")
 
-        url = "#{params[:tpa_host]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/#{params[:app_identifier]}/symbols/"
+        url = "#{params[:base_url]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/#{params[:app_identifier]}/symbols/"
 
         begin
           res = RestClient.get(url, { :"X-API-Key" => params[:api_key] })
@@ -80,7 +80,7 @@ module Fastlane
           end
 
           # Constructs the url
-          url = "#{params[:tpa_host]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/#{meta_data[:app_identifier]}/versions/#{meta_data[:build]}/symbols/"
+          url = "#{params[:base_url]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/#{meta_data[:app_identifier]}/versions/#{meta_data[:build]}/symbols/"
 
           # Uploads the dSYM to TPA
           RestClient.post(url, { version_string: meta_data[:version], mapping: File.new(path, 'rb') }, { :"X-API-Key" => params[:api_key] })

--- a/lib/fastlane/plugin/tpa/helper/tpa_helper.rb
+++ b/lib/fastlane/plugin/tpa/helper/tpa_helper.rb
@@ -1,11 +1,33 @@
 module Fastlane
   module Helper
     class TpaHelper
-      # class methods that you define here become available in your action
-      # as `Helper::TpaHelper.your_method`
-      #
-      def self.show_message
-        UI.message("Hello from the tpa plugin helper!")
+      # Specifies a list of ConfigItems that all the actions have as available options
+      def self.shared_available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :tpa_host,
+                                       env_name: "FL_TPA_HOST_URL",
+                                       description: "The TPA host url",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The TPA host cannot be empty") if value.to_s.length.zero?
+                                         UI.user_error!("Please specify a host name beginning with https://") unless value.start_with?("https://")
+                                         UI.user_error!("Please specify a host name which ends with .tpa.io") unless value.end_with?(".tpa.io", ".tpa.io/")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_uuid,
+                                       env_name: "FL_TPA_API_UUID",
+                                       description: "The API UUID of the project",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The TPA API UUID cannot be empty") if value.to_s.length.zero?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "FL_TPA_API_KEY",
+                                       description: "An API key to TPA",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The TPA API key cannot be empty") if value.to_s.length.zero?
+                                       end)
+        ]
       end
     end
   end

--- a/lib/fastlane/plugin/tpa/helper/tpa_helper.rb
+++ b/lib/fastlane/plugin/tpa/helper/tpa_helper.rb
@@ -4,28 +4,28 @@ module Fastlane
       # Specifies a list of ConfigItems that all the actions have as available options
       def self.shared_available_options
         [
-          FastlaneCore::ConfigItem.new(key: :tpa_host,
-                                       env_name: "FL_TPA_HOST_URL",
-                                       description: "The TPA host url",
+          FastlaneCore::ConfigItem.new(key: :base_url,
+                                       env_name: "FL_TPA_BASE_URL",
+                                       description: "The Base URL for your TPA",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("The TPA host cannot be empty") if value.to_s.length.zero?
-                                         UI.user_error!("Please specify a host name beginning with https://") unless value.start_with?("https://")
-                                         UI.user_error!("Please specify a host name which ends with .tpa.io") unless value.end_with?(".tpa.io", ".tpa.io/")
+                                         UI.user_error!("The Base URL cannot be empty") if value.to_s.length.zero?
+                                         UI.user_error!("Please specify a Base URL beginning with https://") unless value.start_with?("https://")
+                                         UI.user_error!("Please specify a Base URL which ends with .tpa.io") unless value.end_with?(".tpa.io", ".tpa.io/")
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_uuid,
                                        env_name: "FL_TPA_API_UUID",
-                                       description: "The API UUID of the project",
+                                       description: "The API UUID of your TPA project",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("The TPA API UUID cannot be empty") if value.to_s.length.zero?
+                                         UI.user_error!("The API UUID cannot be empty") if value.to_s.length.zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
                                        env_name: "FL_TPA_API_KEY",
-                                       description: "An API key to TPA",
+                                       description: "Your API key to access the TPA REST API",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("The TPA API key cannot be empty") if value.to_s.length.zero?
+                                         UI.user_error!("The API key cannot be empty") if value.to_s.length.zero?
                                        end)
         ]
       end

--- a/spec/tpa_action_spec.rb
+++ b/spec/tpa_action_spec.rb
@@ -7,11 +7,12 @@ describe Fastlane::Actions::TpaAction do
     end
 
     it "upload url is returned correctly" do
-      url = 'https://someproject.tpa.io/some-very-special-uuid/upload'
-      expect(Fastlane::Actions::TpaAction.upload_url(upload_url: url)).to eq url
-
-      url = 'My Not So Normal URL ?__.../\.'
-      expect(Fastlane::Actions::TpaAction.upload_url(upload_url: url)).to eq url
+      params = {
+        tpa_host: "https://someproject.tpa.io",
+        api_uuid: "some-very-special-uuid"
+      }
+      url = "#{params[:tpa_host]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/versions/app/"
+      expect(Fastlane::Actions::TpaAction.upload_url(params)).to eq(url)
     end
 
     it "raises an error if result is not 'OK'" do
@@ -22,8 +23,8 @@ describe Fastlane::Actions::TpaAction do
       end.to raise_exception("Something went wrong while uploading your app to TPA: #{result}")
     end
 
-    it "does not raise an error if result is '200'" do
-      result = "| http_status 200"
+    it "does not raise an error if result is '201'" do
+      result = "| http_status 201"
 
       expect do
         Fastlane::Actions::TpaAction.fail_on_error(result)
@@ -38,7 +39,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload')
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678')
       end").runner.execute(:test)
 
       expect(result).to include("-F app=@\"/tmp/file.ipa\"")
@@ -46,7 +49,7 @@ describe Fastlane::Actions::TpaAction do
       expect(result).to include("-F force=false")
       expect(result).not_to include("--silent") # Do not include silent because of progress-bar
       expect(result).to include("--progress-bar")
-      expect(result).to include("https://my.tpa.io/xxx-yyy-zz/upload")
+      expect(result).to include("https://my.tpa.io/rest/api/v2/projects/xxx-yyy-zz/apps/versions/app/")
     end
 
     it "should include release notes if provided" do
@@ -54,7 +57,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload',
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678',
             notes: 'Now with iMessages extension a.k.a stickers for everyone!')
       end").runner.execute(:test)
 
@@ -66,7 +71,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload',
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678',
             publish: true)
       end").runner.execute(:test)
 
@@ -78,7 +85,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload',
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678',
             progress_bar: false)
       end").runner.execute(:test)
 
@@ -91,7 +100,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload',
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678',
             force: true)
       end").runner.execute(:test)
 
@@ -103,7 +114,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload',
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678',
             mapping: '/tmp/file.dSYM.zip')
       end").runner.execute(:test)
 
@@ -115,7 +128,9 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(apk: '/tmp/file.apk',
-            upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload')
+            tpa_host: 'https://my.tpa.io',
+            api_uuid: 'xxx-yyy-zz',
+            api_key: '12345678')
       end").runner.execute(:test)
 
       expect(result).to include("-F app=@\"/tmp/file.apk\"")
@@ -132,7 +147,9 @@ describe Fastlane::Actions::TpaAction do
         result = Fastlane::FastFile.new.parse("lane :test do
           tpa(apk: '/tmp/file.apk',
               ipa: '/tmp/file.ipa',
-              upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload')
+              tpa_host: 'https://my.tpa.io',
+              api_uuid: 'xxx-yyy-zz',
+              api_key: '12345678')
         end").runner.execute(:test)
       end.to raise_exception("You can't use 'apk' and 'ipa' options in one run")
 
@@ -140,7 +157,9 @@ describe Fastlane::Actions::TpaAction do
         result = Fastlane::FastFile.new.parse("lane :test do
           tpa(ipa: '/tmp/file.ipa',
               apk: '/tmp/file.apk',
-              upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload')
+              tpa_host: 'https://my.tpa.io',
+              api_uuid: 'xxx-yyy-zz',
+              api_key: '12345678')
         end").runner.execute(:test)
       end.to raise_exception("You can't use 'ipa' and 'apk' options in one run")
     end
@@ -153,7 +172,9 @@ describe Fastlane::Actions::TpaAction do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH] = nil
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          tpa(upload_url: 'https://my.tpa.io/xxx-yyy-zz/upload')
+          tpa(tpa_host: 'https://my.tpa.io',
+              api_uuid: 'xxx-yyy-zz',
+              api_key: '12345678')
         end").runner.execute(:test)
       end.to raise_exception("You have to provide a build file")
     end

--- a/spec/tpa_action_spec.rb
+++ b/spec/tpa_action_spec.rb
@@ -8,10 +8,10 @@ describe Fastlane::Actions::TpaAction do
 
     it "upload url is returned correctly" do
       params = {
-        tpa_host: "https://someproject.tpa.io",
+        base_url: "https://someproject.tpa.io",
         api_uuid: "some-very-special-uuid"
       }
-      url = "#{params[:tpa_host]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/versions/app/"
+      url = "#{params[:base_url]}/rest/api/v2/projects/#{params[:api_uuid]}/apps/versions/app/"
       expect(Fastlane::Actions::TpaAction.upload_url(params)).to eq(url)
     end
 
@@ -39,7 +39,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678')
       end").runner.execute(:test)
@@ -57,7 +57,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678',
             notes: 'Now with iMessages extension a.k.a stickers for everyone!')
@@ -71,7 +71,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678',
             publish: true)
@@ -85,7 +85,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678',
             progress_bar: false)
@@ -100,7 +100,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678',
             force: true)
@@ -114,7 +114,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(ipa: '/tmp/file.ipa',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678',
             mapping: '/tmp/file.dSYM.zip')
@@ -128,7 +128,7 @@ describe Fastlane::Actions::TpaAction do
       FileUtils.touch file_path
       result = Fastlane::FastFile.new.parse("lane :test do
         tpa(apk: '/tmp/file.apk',
-            tpa_host: 'https://my.tpa.io',
+            base_url: 'https://my.tpa.io',
             api_uuid: 'xxx-yyy-zz',
             api_key: '12345678')
       end").runner.execute(:test)
@@ -147,7 +147,7 @@ describe Fastlane::Actions::TpaAction do
         result = Fastlane::FastFile.new.parse("lane :test do
           tpa(apk: '/tmp/file.apk',
               ipa: '/tmp/file.ipa',
-              tpa_host: 'https://my.tpa.io',
+              base_url: 'https://my.tpa.io',
               api_uuid: 'xxx-yyy-zz',
               api_key: '12345678')
         end").runner.execute(:test)
@@ -157,7 +157,7 @@ describe Fastlane::Actions::TpaAction do
         result = Fastlane::FastFile.new.parse("lane :test do
           tpa(ipa: '/tmp/file.ipa',
               apk: '/tmp/file.apk',
-              tpa_host: 'https://my.tpa.io',
+              base_url: 'https://my.tpa.io',
               api_uuid: 'xxx-yyy-zz',
               api_key: '12345678')
         end").runner.execute(:test)
@@ -172,7 +172,7 @@ describe Fastlane::Actions::TpaAction do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH] = nil
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          tpa(tpa_host: 'https://my.tpa.io',
+          tpa(base_url: 'https://my.tpa.io',
               api_uuid: 'xxx-yyy-zz',
               api_key: '12345678')
         end").runner.execute(:test)


### PR DESCRIPTION
- Updated the `tpa_action` to use v2 of the TPA REST API in order to provide consistency across the two actions and improved security when interacting with the TPA REST API.

- Removed the deprecated `upload_url` parameter.

- Moved shared ConfigItems to a helper class to ensure they are consistent across actions.

- Updated naming of the parameters to match the ones specified in the TPA website